### PR TITLE
encryptedData field not populated properly

### DIFF
--- a/lib/AggregatesClient.ts
+++ b/lib/AggregatesClient.ts
@@ -58,7 +58,6 @@ export interface AggregateMetadata {
 export interface Commit {
   events: EventEnvelope<DomainEvent>[];
   expectedVersion?: number;
-  encryptedData?: string;
 }
 
 class AggregatesClient<A> extends BaseClient {

--- a/tests/unit/aggregates-client.spec.ts
+++ b/tests/unit/aggregates-client.spec.ts
@@ -342,14 +342,12 @@ describe('Aggregate client', () => {
     const aggregateType = 'game';
     const aggregateId = uuidv4();
 
-    const encryptedData = 'some-secret-stuff';
     const expectedVersion = 1;
 
     const path = AggregatesClient.aggregateEventsUrlPath(aggregateType, aggregateId)
     nock('https://api.serialized.io')
         .post(path, request => {
           expect(request.expectedVersion).toStrictEqual(expectedVersion)
-          expect(request.encryptedData).toStrictEqual(encryptedData)
           return true
         })
         .matchHeader('Serialized-Access-Key', config.accessKey)
@@ -363,7 +361,6 @@ describe('Aggregate client', () => {
           return {
             events: [EventEnvelope.fromDomainEvent(new GameCreated(aggregateId, creationTime))],
             expectedVersion,
-            encryptedData
           }
         });
         expect(eventCount).toStrictEqual(1)


### PR DESCRIPTION
Malplaced field was removed.

Field 'encryptedData' in EventEnvelope needs to be properly populated before merge.