### PR TITLE
Add support for default handler

### DIFF
--- a/lib/AggregatesClient.ts
+++ b/lib/AggregatesClient.ts
@@ -3,19 +3,19 @@ import {Conflict, isSerializedApiError} from "./error";
 import {NoRetryStrategy, RetryStrategy} from "./RetryStrategy";
 import {StateLoader} from "./StateLoader";
 
-type AggregateType = string;
-type AggregateData = object
+type EventType = string;
+type EventData = object
 type AggregateId = string;
 type TenantId = string;
 
-export type DomainEvent<T extends AggregateType, D extends AggregateData> = {
+export type DomainEvent<T extends EventType, D extends EventData> = {
   readonly eventType: T
   readonly data?: D
   readonly eventId?: string
   readonly encryptedData?: string;
 }
 
-export type AggregatesClientConfig<T extends AggregateType> = {
+export type AggregatesClientConfig<T extends EventType> = {
   readonly aggregateType: T
   readonly retryStrategy?: RetryStrategy
 }

--- a/lib/StateBuilder.ts
+++ b/lib/StateBuilder.ts
@@ -1,10 +1,34 @@
+import {DomainEvent} from "./AggregatesClient";
+
 type EventHandlers<S, Events extends { eventType: string }> = {
-  [E in Events as `apply${E["eventType"]}`]: (currentState: S, event: E) => S;
+  [E in Events as `apply${E["eventType"]}`]?: (currentState: S, event: E) => S;
 }
 
+/**
+ * Builder of aggregate state.
+ *
+ * Implements apply methods for all events that are relevant to the aggregate.
+ *
+ * This type also contains methods for a fallback default handler and initial state for the aggregate.
+ */
 type StateBuilder<S, Events extends { eventType: string }> = {
 
+  /**
+   * Initial state of the aggregate.
+   *
+   * Should return a map of the initial state of the aggregate (e.g. {orderId: null, status: 'UNDEFINED'}).
+   */
   initialState: () => S;
+
+  /**
+   * Default handler for events that are not handled by the state builder.
+   *
+   * Typically this is used to handle events that are no longer relevant to the aggregate but are still stored in the event store.
+   * If this is not provided, the state builder will throw an error when an unsupported event is loaded.
+   *
+   * @param e the loaded event
+   */
+  defaultHandler?: (currentState: S, e: DomainEvent<string, any>) => S;
 
 } & EventHandlers<S, Events>
 

--- a/lib/StateLoader.ts
+++ b/lib/StateLoader.ts
@@ -1,10 +1,25 @@
 import {StateBuilder} from "./StateBuilder";
+import {UnhandledEventTypeError} from "./error";
 
+/**
+ * State builder for an aggregate.
+ *
+ * Loads the current state of an aggregate based on from the events that have been stored in the aggregate.
+ */
 export class StateLoader<S, E extends { eventType: string }> {
   loadState(currentState: S, stateBuilder: StateBuilder<S, E>, events: E[]) {
     events.forEach(e => {
-      let eventType = e.eventType;
-      currentState = stateBuilder[`apply${eventType}`](currentState, e)
+      const eventType = e.eventType;
+      const eventHandler = stateBuilder[`apply${eventType}`];
+      if (!eventHandler) {
+        if (stateBuilder.defaultHandler) {
+          stateBuilder.defaultHandler(currentState, e)
+        } else {
+          throw new UnhandledEventTypeError(eventType)
+        }
+      } else {
+        currentState = eventHandler(currentState, e)
+      }
     })
     return currentState;
   }

--- a/lib/error.ts
+++ b/lib/error.ts
@@ -58,6 +58,26 @@ export class UnexpectedClientError extends SerializedError {
 }
 
 /**
+ * Thrown if an error occurs in the client
+ */
+export class ClientError extends SerializedError {
+  constructor(public message: string, public cause?: Error) {
+    super(message);
+    this.name = 'ClientError'
+  }
+}
+
+/**
+ * Throw if an event is loaded that has no handler registered and no default handler is registered.
+ */
+export class UnhandledEventTypeError extends ClientError {
+  constructor(public readonly eventType: string) {
+    super(`No event handler found for event type ${eventType}.`);
+    this.name = 'UnhandledEventTypeError'
+  }
+}
+
+/**
  * Thrown if the client sent a request with an invalid payload.
  */
 export class InvalidPayloadError extends SerializedApiError {

--- a/tests/unit/game/game.ts
+++ b/tests/unit/game/game.ts
@@ -43,6 +43,22 @@ const stateBuilder: StateBuilder<GameState, GameEvent> = {
   },
   applyGameFinished: (state, event) => {
     return {...state, gameId: event.data.gameId, status: GameStatus.FINISHED}
+  },
+}
+
+/**
+ * Illustrates how to use default handler and implement event handlers for a subset of the events.
+ */
+const safeStateBuilder: StateBuilder<GameState, GameEvent> = {
+  initialState: () => {
+    return {gameId: '', status: GameStatus.UNDEFINED}
+  },
+  applyGameCreated: (state, event) => {
+    return {...state, gameId: event.data.gameId, status: GameStatus.CREATED}
+  },
+  defaultHandler: (state, event) => {
+    console.log(`Unsupported event: ${event.eventType}. Skipping it.`);
+    return state
   }
 }
 
@@ -112,8 +128,16 @@ const createGameClient = (serialized: SerializedInstance, retryStrategy?: RetryS
   }, stateBuilder, (state: GameState) => new Game(state));
 }
 
+const createSafeGameClient = (serialized: SerializedInstance, retryStrategy?: RetryStrategy) => {
+  return serialized.aggregateClient({
+    aggregateType: 'game',
+    retryStrategy: retryStrategy || new NoRetryStrategy()
+  }, safeStateBuilder, (state: GameState) => new Game(state));
+}
+
 export {
   createGameClient,
+  createSafeGameClient,
   stateBuilder,
   Game,
   GameState,


### PR DESCRIPTION
- Allow (optional) custom handling of event with a fallback default handler.
- Introduced typed error `UnhandledEventTypeError` for the case when an event handler is missing.
- Make typed event handlers optional to support combination of default handler and typed handlers